### PR TITLE
fix: tiled window geometry restore

### DIFF
--- a/src/core/layout/dwindle.rs
+++ b/src/core/layout/dwindle.rs
@@ -41,7 +41,7 @@ pub struct RestoreStep {
 }
 
 /// Post-placement correction: focus this window and apply
-/// `layoutmsg splitratio exact <ratio>` to set its parent split precisely.
+/// `layoutmsg splitratio <delta>` to set its parent split precisely.
 #[derive(Debug, Clone)]
 pub struct SplitRatioStep {
     pub focus_window_idx: usize,
@@ -542,5 +542,26 @@ mod tests {
         let wp = build_workspace_plan(&refs, &[0, 1]).unwrap();
         assert_eq!(wp.ratio_steps.len(), 1);
         assert!((wp.ratio_steps[0].ratio - 0.6).abs() < 0.01);
+    }
+
+    #[test]
+    fn four_windows_nested_with_large_gap_between_non_adjacent() {
+        //  +--------+----------+------+
+        //  |        |          |  c   |
+        //  |   a    |    d     |      |
+        //  |        |          +------+
+        //  |        |          |  b   |
+        //  +--------+----------+------+
+        let a = make_entry("a", "2", 21, 69, 1112, 1350);
+        let b = make_entry("b", "2", 2062, 1124, 477, 295);
+        let c = make_entry("c", "2", 2062, 69, 477, 1033);
+        let d = make_entry("d", "2", 1155, 69, 885, 1350);
+        let refs: Vec<&WindowEntry> = vec![&a, &b, &c, &d];
+        let plan = build_workspace_plan(&refs, &[0, 1, 2, 3]);
+        assert!(
+            plan.is_some(),
+            "BSP inference should succeed for 4-window dwindle layout with gaps"
+        );
+        assert_eq!(plan.unwrap().steps.len(), 4);
     }
 }

--- a/src/core/layout/mod.rs
+++ b/src/core/layout/mod.rs
@@ -46,31 +46,34 @@ pub fn extract_indexed(
         .collect()
 }
 
-/// Measure the largest pixel gap between adjacent tiled windows by examining
-/// pairs that overlap in the perpendicular axis. Returns 0 when no gaps are
-/// found (e.g. `gaps_in = 0` or a single window).
+/// Measure the smallest pixel gap between tiled windows that overlap in the
+/// perpendicular axis. This finds the actual Hyprland `gaps_in` value by
+/// picking the minimum non-zero gap — truly adjacent windows always have the
+/// smallest distance, while non-adjacent pairs (separated by other windows)
+/// have larger distances that would inflate tolerance and break BSP inference.
+/// Returns 0 when no gaps are found (e.g. `gaps_in = 0` or a single window).
 pub fn infer_gap_from_geometry(indexed: &[IndexedWindow]) -> i32 {
     if indexed.len() < 2 {
         return 0;
     }
 
-    let mut max_gap = 0i32;
+    let mut min_gap = i32::MAX;
     for a in indexed {
         for b in indexed {
             // b is to the right of a, and they share vertical overlap
             let h_gap = b.x - (a.x + a.w);
             if h_gap > 0 && ranges_overlap(a.y, a.y + a.h, b.y, b.y + b.h) {
-                max_gap = max_gap.max(h_gap);
+                min_gap = min_gap.min(h_gap);
             }
 
             // b is below a, and they share horizontal overlap
             let v_gap = b.y - (a.y + a.h);
             if v_gap > 0 && ranges_overlap(a.x, a.x + a.w, b.x, b.x + b.w) {
-                max_gap = max_gap.max(v_gap);
+                min_gap = min_gap.min(v_gap);
             }
         }
     }
-    max_gap
+    if min_gap == i32::MAX { 0 } else { min_gap }
 }
 
 pub const fn ranges_overlap(a_start: i32, a_end: i32, b_start: i32, b_end: i32) -> bool {

--- a/src/core/restore.rs
+++ b/src/core/restore.rs
@@ -647,9 +647,9 @@ impl RestoreEngine {
         }
     }
 
-    /// Apply `layoutmsg splitratio exact` for each split node in the BSP tree
-    /// that has a direct leaf child. This is deterministic and far more
-    /// reliable than iterative pixel-delta convergence.
+    /// Apply `layoutmsg splitratio <delta>` for each split node in the BSP tree
+    /// that has a direct leaf child. The delta is computed from the default 0.5
+    /// ratio since freshly-created windows always start at the default.
     async fn apply_split_ratios(
         &self,
         ctl: &HyprCtl,
@@ -670,8 +670,9 @@ impl RestoreEngine {
                     tracing::warn!("splitratio: focus failed: {e}");
                     continue;
                 }
+                let delta = step.ratio - 0.5;
                 match ctl
-                    .dispatch(&format!("layoutmsg splitratio exact {:.6}", step.ratio))
+                    .dispatch(&format!("layoutmsg splitratio {delta:.6}"))
                     .await
                 {
                     Ok(resp) if resp.trim() != "ok" => {


### PR DESCRIPTION
## Summary
- Fix `layoutmsg splitratio exact` failing on Hyprland. The `exact` keyword is not supported by `splitratio`, so tiled split ratios were silently never applied. Now sends a delta from the default 0.5 instead.
- Fix BSP inference failing on workspaces with 3+ tiled windows by using the minimum inter-window gap instead of the maximum. Non-adjacent window pairs (separated by other windows) were inflating the tolerance and making clean BSP partitioning impossible.
- Attempt for https://github.com/IraSkyx/hyprresume/issues/7